### PR TITLE
Upgrade target framework from net6.0 to net10.0

### DIFF
--- a/Yale.Performance.csproj
+++ b/Yale.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- Upgrades `TargetFramework` in `Yale.Performance.csproj` from `net6.0` to `net10.0` (the latest LTS release as of 2026)

## Test plan

- [ ] Verify `dotnet restore` succeeds with .NET 10 SDK
- [ ] Verify `dotnet build` compiles without errors
- [ ] Verify `dotnet run` executes the performance benchmark correctly

https://claude.ai/code/session_0186SWxkAWgtsSKd6PYBKHY6

---
_Generated by [Claude Code](https://claude.ai/code/session_0186SWxkAWgtsSKd6PYBKHY6)_